### PR TITLE
Change the order of the meta tags to fix SERP preview

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,7 +1,6 @@
 <html lang="en">
   <head>
     <meta charset="utf-8">
-    <meta http-equiv="refresh" content="0; URL=https://kotlinlang.org/" />
     <link rel="icon" href="https://kotlinlang.org/assets/images/favicon.svg?v2" type="image/svg+xml">
     <link rel="alternate icon" href="https://kotlinlang.org/assets/images/favicon.ico?v2" type="image/x-icon">
     <link rel="apple-touch-icon" sizes="57x57" href="https://kotlinlang.org/assets/images/apple-touch-icon.png?v2">
@@ -9,5 +8,6 @@
     <meta property="og:site_name" content="Kotlin">
     <meta property="og:title" content="Kotlin">
     <meta property="og:type" content="website">
+    <meta http-equiv="refresh" content="0; URL=https://kotlinlang.org/" />
   </head>
 </html>


### PR DESCRIPTION
I suggest changing the order of the tags to correct the site name in the Google search preview.